### PR TITLE
Fix undefined method post_install_messages

### DIFF
--- a/exe/bundle-only
+++ b/exe/bundle-only
@@ -30,11 +30,11 @@ definition.validate_ruby!
 
 Bundler.ui = Bundler::UI::Shell.new
 
-Bundler::Installer.install(Bundler.root, definition, system: true)
+installer = Bundler::Installer.install(Bundler.root, definition, system: true)
 
 BundleOnly::Messages.print_installation_complete(definition)
 BundleOnly::Messages.confirm_without_groups
 
-Bundler::Installer.post_install_messages.each do |name, message|
+installer.post_install_messages.each do |name, message|
   BundleOnly::Messages.print_post_install_message(name, message)
 end


### PR DESCRIPTION
Hi,

bundle-only did throw an error with bundler version > 1.12.5 for rubocop

```
/usr/local/share/gems/gems/bundle-only-0.1.1/exe/bundle-only:38:in `<top (required)>': undefined method `post_install_messages' for Bundler::Installer:Class (NoMethodError)
    from /usr/local/bin/bundle-only:23:in `load'
    from /usr/local/bin/bundle-only:23:in `<main>                                                                                                                                                                                                                                                                           `
```
